### PR TITLE
Adding customization to workloads created by connectivity tests

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -17,6 +17,7 @@ package check
 import (
 	"fmt"
 	"io"
+	corev1 "k8s.io/api/core/v1"
 	"regexp"
 	"time"
 
@@ -45,6 +46,8 @@ type Parameters struct {
 	Verbose               bool
 	Debug                 bool
 	PauseOnFail           bool
+	GlobalTolerations     []corev1.Toleration
+	AgentDaemonSetName    string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -386,7 +386,7 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	// environment so we can skip deploying tests which depend on multiple
 	// nodes.
 	if ct.params.MultiCluster == "" && !ct.params.SingleNode {
-		daemonSet, err := ct.client.GetDaemonSet(ctx, ct.params.CiliumNamespace, defaults.AgentDaemonSetName, metav1.GetOptions{})
+		daemonSet, err := ct.client.GetDaemonSet(ctx, ct.params.CiliumNamespace, ct.params.AgentDaemonSetName, metav1.GetOptions{})
 		if err != nil {
 			ct.Fatal("Unable to determine status of Cilium DaemonSet. Run \"cilium status\" for more details")
 			return fmt.Errorf("unable to determine status of Cilium DaemonSet: %w", err)

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"os/signal"
 	"regexp"
@@ -43,9 +44,11 @@ func newCmdConnectivity() *cobra.Command {
 }
 
 var params = check.Parameters{
-	Writer: os.Stdout,
+	Writer:            os.Stdout,
+	GlobalTolerations: []corev1.Toleration{},
 }
 var tests []string
+var podTolerations []string
 
 func newCmdConnectivityTest() *cobra.Command {
 	cmd := &cobra.Command{
@@ -68,6 +71,34 @@ func newCmdConnectivityTest() *cobra.Command {
 					}
 					params.RunTests = append(params.RunTests, rgx)
 				}
+			}
+
+			// Validate toleration string
+			var allowedEffects = []string{"NoSchedule", "NoExecute", "PreferNoSchedule"}
+			for _, toleration := range podTolerations {
+				tolerationString := strings.Split(toleration, ":")
+				if len(tolerationString) < 2 {
+					return fmt.Errorf("invalid format: %s, toleration string should be of format key1=value1:effect", toleration)
+				}
+				validEffect := false
+				for _, e := range allowedEffects {
+					if tolerationString[1] == e {
+						validEffect = true
+					}
+				}
+				if !validEffect {
+					return fmt.Errorf("invalid effect: %s, toleration effect should be either NoSchedule, NoExecute or PreferNoSchedule", tolerationString[1])
+				}
+				kv := strings.Split(tolerationString[0], "=")
+				if len(kv) < 2 || len(kv[0]) == 0 || len(kv[1]) == 0 {
+					return fmt.Errorf("invalid key value pair: %s", tolerationString[0])
+				}
+				params.GlobalTolerations = append(params.GlobalTolerations, corev1.Toleration{
+					Key:      kv[0],
+					Operator: "Equal",
+					Value:    kv[1],
+					Effect:   corev1.TaintEffect(tolerationString[1]),
+				})
 			}
 
 			// Instantiate the test harness.
@@ -101,9 +132,11 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.HubbleServer, "hubble-server", "localhost:4245", "Address of the Hubble endpoint for flow validation")
 	cmd.Flags().StringVarP(&params.CiliumNamespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
 	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity test in")
+	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
+	cmd.Flags().StringSliceVar(&podTolerations, "pod-tolerations", []string{}, "Tolerations to add to test workloads and client pods. Comma separated values of the format key1=value1:effect, effect can be NoSchedule, NoExecute or PreferNoSchedule")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
 	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages and don't buffer any lines")


### PR DESCRIPTION
Add support for :
* Adding tolerations to pods created by connectivity tests.
* Customizing cilium-agent's daemonset name (defaults to cilium)
* Continue to run tests when `ciliumexternalworkloads.cilium.io` CRD is missing (needed for pre 1.9 clusters)