### PR TITLE
Support for tolerations to test workloads and agent DS name override

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -47,6 +47,7 @@ type Parameters struct {
 	JSONMockImage         string
 	GlobalTolerations     []corev1.Toleration
 	AgentDaemonSetName    string
+	DNSTestServerImage    string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/observer"
 
@@ -43,6 +45,8 @@ type Parameters struct {
 	CurlImage             string
 	PerformanceImage      string
 	JSONMockImage         string
+	GlobalTolerations     []corev1.Toleration
+	AgentDaemonSetName    string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/check/context.go
+++ b/connectivity/check/context.go
@@ -428,7 +428,7 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	// environment so we can skip deploying tests which depend on multiple
 	// nodes.
 	if ct.params.MultiCluster == "" && !ct.params.SingleNode {
-		daemonSet, err := ct.client.GetDaemonSet(ctx, ct.params.CiliumNamespace, defaults.AgentDaemonSetName, metav1.GetOptions{})
+		daemonSet, err := ct.client.GetDaemonSet(ctx, ct.params.CiliumNamespace, ct.params.AgentDaemonSetName, metav1.GetOptions{})
 		if err != nil {
 			ct.Fatal("Unable to determine status of Cilium DaemonSet. Run \"cilium status\" for more details")
 			return fmt.Errorf("unable to determine status of Cilium DaemonSet: %w", err)

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -36,7 +36,6 @@ const (
 	Client2DeploymentName = "client2"
 
 	DNSTestServerContainerName = "dns-test-server"
-	DNSTestServerImage         = "coredns/coredns:1.9.3@sha256:bdb36ee882c13135669cfc2bb91c808a33926ad1a411fee07bd2dc344bb8f782"
 
 	echoSameNodeDeploymentName  = "echo-same-node"
 	echoOtherNodeDeploymentName = "echo-other-node"
@@ -161,7 +160,7 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 	return dep
 }
 
-func newDeploymentWithDNSTestServer(p deploymentParameters) *appsv1.Deployment {
+func newDeploymentWithDNSTestServer(p deploymentParameters, DNSTestServerImage string) *appsv1.Deployment {
 	dep := newDeployment(p)
 
 	dep.Spec.Template.Spec.Containers = append(
@@ -360,7 +359,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			},
 			Tolerations:    ct.params.GlobalTolerations,
 			ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
-		})
+		}, ct.params.DNSTestServerImage)
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoDeployment, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to create deployment %s: %s", echoSameNodeDeploymentName, err)
@@ -614,7 +613,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				},
 				ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
 				Tolerations:    ct.params.GlobalTolerations,
-			})
+			}, ct.params.DNSTestServerImage)
 			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeployment, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("unable to create deployment %s: %w", echoOtherNodeDeploymentName, err)

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -94,6 +94,7 @@ type deploymentParameters struct {
 	ReadinessProbe *corev1.Probe
 	Labels         map[string]string
 	HostNetwork    bool
+	Tolerations    []corev1.Toleration
 }
 
 func newDeployment(p deploymentParameters) *appsv1.Deployment {
@@ -141,6 +142,7 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 					},
 					Affinity:    p.Affinity,
 					HostNetwork: p.HostNetwork,
+					Tolerations: p.Tolerations,
 				},
 			},
 			Replicas: &replicas32,
@@ -152,7 +154,6 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 			},
 		},
 	}
-
 	for k, v := range p.Labels {
 		dep.Spec.Template.ObjectMeta.Labels[k] = v
 	}
@@ -357,6 +358,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					},
 				},
 			},
+			Tolerations:    ct.params.GlobalTolerations,
 			ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoDeployment, metav1.CreateOptions{})
@@ -524,11 +526,12 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:    ClientDeploymentName,
-			Kind:    kindClientName,
-			Port:    8080,
-			Image:   ct.params.CurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
+			Name:        ClientDeploymentName,
+			Kind:        kindClientName,
+			Port:        8080,
+			Image:       ct.params.CurlImage,
+			Tolerations: ct.params.GlobalTolerations,
+			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
@@ -561,6 +564,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					},
 				},
 			},
+			Tolerations: ct.params.GlobalTolerations,
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
 		if err != nil {
@@ -609,6 +613,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					},
 				},
 				ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
+				Tolerations:    ct.params.GlobalTolerations,
 			})
 			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, echoOtherNodeDeployment, metav1.CreateOptions{})
 			if err != nil {

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -67,6 +67,7 @@ const (
 	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956"
 	ConnectivityPerformanceImage     = "quay.io/cilium/network-perf:bf58fb8bc57c4933dfa6e2a9581d3925c0a0571e@sha256:9bef508b2dcaeb3e288a496b8d3f065e8636a4937ba3aebcb1732afffaccea34"
 	ConnectivityCheckJSONMockImage   = "quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b"
+	ConnectivityDNSTestServerImage   = "docker.io/coredns/coredns:1.9.3@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a"
 
 	ConfigMapName = "cilium-config"
 	Version       = "v1.11.6"

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"os"
 	"os/signal"
 	"regexp"
 	"strings"
 	"syscall"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/spf13/cobra"
 
@@ -163,6 +164,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckAlpineCurlImage, "Image path to use for curl")
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
+	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-servier-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS test server")
 
 	return cmd
 }

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"os/signal"
 	"regexp"
@@ -36,9 +37,11 @@ func newCmdConnectivity() *cobra.Command {
 }
 
 var params = check.Parameters{
-	Writer: os.Stdout,
+	Writer:            os.Stdout,
+	GlobalTolerations: []corev1.Toleration{},
 }
 var tests []string
+var podTolerations []string
 
 func newCmdConnectivityTest() *cobra.Command {
 	cmd := &cobra.Command{
@@ -63,6 +66,34 @@ func newCmdConnectivityTest() *cobra.Command {
 					}
 					params.RunTests = append(params.RunTests, rgx)
 				}
+			}
+
+			// Validate toleration string
+			var allowedEffects = []string{"NoSchedule", "NoExecute", "PreferNoSchedule"}
+			for _, toleration := range podTolerations {
+				tolerationString := strings.Split(toleration, ":")
+				if len(tolerationString) < 2 {
+					return fmt.Errorf("invalid format: %s, toleration string should be of format key1=value1:effect", toleration)
+				}
+				validEffect := false
+				for _, e := range allowedEffects {
+					if tolerationString[1] == e {
+						validEffect = true
+					}
+				}
+				if !validEffect {
+					return fmt.Errorf("invalid effect: %s, toleration effect should be either NoSchedule, NoExecute or PreferNoSchedule", tolerationString[1])
+				}
+				kv := strings.Split(tolerationString[0], "=")
+				if len(kv) < 2 || len(kv[0]) == 0 || len(kv[1]) == 0 {
+					return fmt.Errorf("invalid key value pair: %s", tolerationString[0])
+				}
+				params.GlobalTolerations = append(params.GlobalTolerations, corev1.Toleration{
+					Key:      kv[0],
+					Operator: "Equal",
+					Value:    kv[1],
+					Effect:   corev1.TaintEffect(tolerationString[1]),
+				})
 			}
 
 			// Instantiate the test harness.
@@ -113,8 +144,10 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().BoolVar(&params.Hubble, "hubble", true, "Automatically use Hubble for flow validation & troubleshooting")
 	cmd.Flags().StringVar(&params.HubbleServer, "hubble-server", "localhost:4245", "Address of the Hubble endpoint for flow validation")
 	cmd.Flags().StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity test in")
+	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
+	cmd.Flags().StringSliceVar(&podTolerations, "pod-tolerations", []string{}, "Tolerations to add to test workloads and client pods. Comma separated values of the format key1=value1:effect, effect can be NoSchedule, NoExecute or PreferNoSchedule")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
 	cmd.Flags().BoolVar(&params.AllFlows, "all-flows", false, "Print all flows during flow validation")
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages and don't buffer any lines")


### PR DESCRIPTION
Cherry-picks https://github.com/datadog/cilium-cli/pull/1 against the latest 0.11 code (master currently). Lots of merge conflicts but, I think I got them resolved correctly. 

EDIT: Just noting that I did drop the external workload logic as now there's https://github.com/cilium/cilium-cli/commit/a20392d2d3ff8a7f0567f91830b8db635c2d16ec from upstream which appears to handle that case for us. 