### PR TITLE
[connectivity] Retry deleting namespace while waiting

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -657,6 +657,7 @@ func (ct *ConnectivityTest) deleteDeployments(ctx context.Context, client *k8s.C
 		ct.Logf("⌛ [%s] Waiting for namespace %s to disappear", client.ClusterName(), ct.params.TestNamespace)
 		for err == nil {
 			time.Sleep(time.Second)
+			_ = client.DeleteNamespace(ctx, ct.params.TestNamespace, metav1.DeleteOptions{})
 			_, err = client.GetNamespace(ctx, ct.params.TestNamespace, metav1.GetOptions{})
 		}
 	}


### PR DESCRIPTION
When https://github.com/yahoo/k8s-namespace-guard is setup and these are run with `--force-deploy`, we get stuck waiting for the namespace to be deleted here. This is because it takes a while for the pods to get removed after the deployment is gone but, the namespace-guard has already rejected the original deletion request. 

In my testing, the simplest fix is to just add the deletion here which does work once the pods are gone. 