### PR TITLE
Add new --cilium-version option for when auto-detection fails

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -48,6 +48,7 @@ type Parameters struct {
 	GlobalTolerations     []corev1.Toleration
 	AgentDaemonSetName    string
 	DNSTestServerImage    string
+	CiliumVersion         string
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {

--- a/connectivity/suite.go
+++ b/connectivity/suite.go
@@ -58,8 +58,8 @@ func Run(ctx context.Context, ct *check.ConnectivityTest) error {
 	var v semver.Version
 	helmState, err := ct.K8sClient().GetHelmState(ctx, ct.Params().CiliumNamespace, defaults.HelmValuesSecretName)
 	if err != nil {
-		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests", defaults.Version)
-		v, err = utils.ParseCiliumVersion(defaults.Version)
+		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests", ct.Params().CiliumVersion)
+		v, err = utils.ParseCiliumVersion(ct.Params().CiliumVersion)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -165,6 +165,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-servier-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS test server")
+	cmd.Flags().StringVar(&params.CiliumVersion, "cilium-version", defaults.Version, "Cilium version to test against")
 
 	return cmd
 }


### PR DESCRIPTION
https://github.com/DataDog/cilium-cli/blob/0.11-dd/connectivity/suite.go#L59 can fail if you don't have the `cilium-cli-helm-values` secret. This adds a basic option to set the cilium version for when the autodetection fails instead of always using 0.11. This is needed for the `allow-all-except-world` test when running on clusters before 0.11. 