### PR TITLE
Support for tolerations to test workloads

### DIFF
--- a/connectivity/check/check.go
+++ b/connectivity/check/check.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/observer"
 
@@ -48,6 +50,7 @@ type Parameters struct {
 	AgentDaemonSetName    string
 	DNSTestServerImage    string
 	Datapath              bool
+	GlobalTolerations     []corev1.Toleration
 }
 
 func (p Parameters) ciliumEndpointTimeout() time.Duration {


### PR DESCRIPTION
Cherry-pick of https://github.com/DataDog/cilium-cli/pull/2 to 0.12 
I still think we don't need to do this if we can get the namespace tolerations working. Just need to work on that a bit. This worked locally. 

The rest of the changes we did for 0.11 were upstreamed, merged, and already included. 