### PR TITLE
[connectivity] Allow node-local-dns access for related tests

### DIFF
--- a/connectivity/manifests/allow-all-except-world-pre-v1.11.yaml
+++ b/connectivity/manifests/allow-all-except-world-pre-v1.11.yaml
@@ -14,6 +14,8 @@ spec:
     - health
   - toEndpoints:
     - {}
+  - toCIDR:
+    - 169.254.20.10/32
   ingress:
   - fromEntities:
     - host

--- a/connectivity/manifests/client-egress-only-dns.yaml
+++ b/connectivity/manifests/client-egress-only-dns.yaml
@@ -25,3 +25,9 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: kube-system
         k8s-app: node-local-dns
+    - matchLabels:
+        io.kubernetes.pod.namespace: cluster-dns
+        app: coredns
+    - matchLabels:
+        io.kubernetes.pod.namespace: cluster-dns-node-local
+        app: node-local-dns

--- a/connectivity/manifests/client-egress-to-echo.yaml
+++ b/connectivity/manifests/client-egress-to-echo.yaml
@@ -24,3 +24,9 @@ spec:
     - matchExpressions:
       - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+    - matchLabels:
+        io.kubernetes.pod.namespace: cluster-dns
+        app: coredns
+    - matchLabels:
+        io.kubernetes.pod.namespace: cluster-dns-node-local
+        app: node-local-dns

--- a/connectivity/manifests/client-egress-to-entities-world.yaml
+++ b/connectivity/manifests/client-egress-to-entities-world.yaml
@@ -22,3 +22,5 @@ spec:
     - ports:
       - port: "53"
         protocol: ANY
+  - toCIDR:
+    - 169.254.20.10/32

--- a/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
+++ b/connectivity/manifests/client-egress-to-fqdns-one-one-one-one.yaml
@@ -29,3 +29,9 @@ spec:
     - matchExpressions:
         - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns" ] }
         - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+    - matchLabels:
+        io.kubernetes.pod.namespace: cluster-dns
+        app: coredns
+    - matchLabels:
+        io.kubernetes.pod.namespace: cluster-dns-node-local
+        app: node-local-dns


### PR DESCRIPTION
This PR updates the various CNP's used in the tests to allow them to work in our clusters. With this setup, I'm able to run the full test suite which passes. 