### PR TITLE
[connectivity] Wait 5 seconds when changing CNPs

### DIFF
--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -614,6 +614,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				},
 			},
 			ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
+			Tolerations:    ct.params.GlobalTolerations,
 		}, ct.params.DNSTestServerImage)
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(echoSameNodeDeploymentName), metav1.CreateOptions{})
 		if err != nil {
@@ -629,12 +630,13 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), clientDeploymentName)
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:      clientDeploymentName,
-			Kind:      kindClientName,
-			NamedPort: "http-8080",
-			Port:      8080,
-			Image:     ct.params.CurlImage,
-			Command:   []string{"/bin/ash", "-c", "sleep 10000000"},
+			Name:        clientDeploymentName,
+			Kind:        kindClientName,
+			NamedPort:   "http-8080",
+			Port:        8080,
+			Image:       ct.params.CurlImage,
+			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
+			Tolerations: ct.params.GlobalTolerations,
 		})
 		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(clientDeploymentName), metav1.CreateOptions{})
 		if err != nil {

--- a/connectivity/check/policy.go
+++ b/connectivity/check/policy.go
@@ -76,6 +76,11 @@ func (t *Test) waitCiliumPolicyRevisions(ctx context.Context, revisions map[Pod]
 			delete(revisions, pod)
 		}
 	}
+
+	// TODO(jared.ledvina): Manual sleep to work around race
+	t.Debug("Waiting 5 seconds for CiliumNetworkPolicy change has taken effect")
+	time.Sleep(5 * time.Second)
+
 	if len(revisions) == 0 {
 		return nil
 	}


### PR DESCRIPTION
This adds a workaround to avoid a race where a CNP is created and we don't wait long enough for it to be applied. I've also added a fix for the tolerations so they are applied to all created deployments. 