### PR TITLE
Fixup typo

### DIFF
--- a/internal/cli/cmd/connectivity.go
+++ b/internal/cli/cmd/connectivity.go
@@ -165,7 +165,7 @@ func newCmdConnectivityTest() *cobra.Command {
 	cmd.Flags().StringVar(&params.CurlImage, "curl-image", defaults.ConnectivityCheckAlpineCurlImage, "Image path to use for curl")
 	cmd.Flags().StringVar(&params.PerformanceImage, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.JSONMockImage, "json-mock-image", defaults.ConnectivityCheckJSONMockImage, "Image path to use for json mock")
-	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-servier-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS test server")
+	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS test server")
 
 	return cmd
 }


### PR DESCRIPTION
🤦 https://github.com/DataDog/cilium-cli/pull/2/files#diff-2c7f88bf75b3d1daf043161a565d93509bf3c692c1dff9fec22ce6bf9b89fcbfR167 

2 years later, let's fix this typo. 