### PR TITLE
connectivity tests: do not deploy client2 on same node as client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 # Outputs of 'cilium sysdump'.
 cilium-sysdump-*/
 cilium-sysdump-*.zip
+
+# IntelliJ
+.idea

--- a/connectivity/check/deployment.go
+++ b/connectivity/check/deployment.go
@@ -499,26 +499,12 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying client2 deployment...", ct.clients.src.ClusterName())
 		clientDeployment := newDeployment(deploymentParameters{
-			Name:    Client2DeploymentName,
-			Kind:    kindClientName,
-			Port:    8080,
-			Image:   ct.params.CurlImage,
-			Command: []string{"/bin/ash", "-c", "sleep 10000000"},
-			Labels:  map[string]string{"other": "client"},
-			Affinity: &corev1.Affinity{
-				PodAffinity: &corev1.PodAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{ClientDeploymentName}},
-								},
-							},
-							TopologyKey: "kubernetes.io/hostname",
-						},
-					},
-				},
-			},
+			Name:        Client2DeploymentName,
+			Kind:        kindClientName,
+			Port:        8080,
+			Image:       ct.params.CurlImage,
+			Command:     []string{"/bin/ash", "-c", "sleep 10000000"},
+			Labels:      map[string]string{"other": "client"},
 			Tolerations: ct.params.GlobalTolerations,
 		})
 		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, clientDeployment, metav1.CreateOptions{})
@@ -559,7 +545,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 							{
 								LabelSelector: &metav1.LabelSelector{
 									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{ClientDeploymentName}},
+										{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{ClientDeploymentName, Client2DeploymentName}},
 									},
 								},
 								TopologyKey: "kubernetes.io/hostname",


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/cilium-cli/pull/10

Same idea: we can't always reliably schedule the two pods on the same node (esp. in GCP) 
This reverts the upstream `cilium-cli` PR 532  

We run the following tests:
```
no-policies/pod-to-world/http-to-one-one-one-one
no-policies/pod-to-world/https-to-one-one-one-one
no-policies/pod-to-world/https-to-one-one-one-one-index
no-policies/client-to-client/ping
no-policies/client-to-client/ping
no-policies/pod-to-pod/curl
no-policies/pod-to-pod/curl
no-policies/pod-to-cidr/cloudflare-1111
no-policies/pod-to-cidr/cloudflare-1111
no-policies/pod-to-cidr/cloudflare-1001
no-policies/pod-to-cidr/cloudflare-1001
no-policies/pod-to-host/ping
no-policies/pod-to-host/ping
no-policies/pod-to-host/ping
no-policies/pod-to-host/ping
no-policies/pod-to-world/https-to-one-one-one-one-index
no-policies/pod-to-world/https-to-one-one-one-one
no-policies/pod-to-world/http-to-one-one-one-one
```

The pod-to-pod tests look like this:
```
[.] Action [no-policies/pod-to-pod/curl-1: cilium-test/client2-7bf89b9b49-cwl64 -> cilium-test/echo-other-node-5566f984b4-5sddl]

[.] Action [no-policies/pod-to-pod/curl-0: cilium-test/client-64bcd58c94-cj674 -> cilium-test/echo-other-node-5566f984b4-5sddl]
```

After the PR is deployed, we will no longer ensure that `client` and `client2` are on the same node but it doesn't matter because we will ensure that `echo-other-node` is on a different node from `client` **and** `client2`